### PR TITLE
fix: Filter out items without poster_path when rendering CardMovies

### DIFF
--- a/app/films/[id]/page.tsx
+++ b/app/films/[id]/page.tsx
@@ -122,6 +122,7 @@ const ContainerMovieSimilar = ({ movie, isLoading }: propsSimilarMovie) => {
   const loadingCardMovies = Array.from({ length: 10 }).map((_, index) => (
     <CardMovie variant="primary" key={index} isLoading={true} />
   ));
+  console.log(movie);
   return (
     <section className="section__page sections__movies">
       <TitleSection variant="title-large" title="FILMS SIMILAIR" />
@@ -131,15 +132,19 @@ const ContainerMovieSimilar = ({ movie, isLoading }: propsSimilarMovie) => {
           : movie &&
             movie
               .slice(0, 20)
-              .map((movie: TypeMovieDetails) => (
-                <CardMovie
-                  key={movie.id}
-                  variant="primary"
-                  poster={movie.poster_path}
-                  title={movie.title}
-                  id={movie.id}
-                />
-              ))}
+              .map(
+                (movie: TypeMovieDetails) =>
+                  movie.poster_path !== null && (
+                    <CardMovie
+                      key={movie.id}
+                      variant="primary"
+                      poster={movie.poster_path}
+                      title={movie.title}
+                      id={movie.id}
+                      cover={movie.backdrop_path}
+                    />
+                  )
+              )}
       </ContainerScroll>
     </section>
   );

--- a/app/films/genre/[id]/page.tsx
+++ b/app/films/genre/[id]/page.tsx
@@ -88,15 +88,18 @@ const ContainerMovie = ({ idCategorie }: propsContainer) => {
       id="content__movie_tv"
     >
       <main className="content">
-        {movieList.map((movie, index) => (
-          <CardMovie
-            key={index}
-            variant="default"
-            poster={movie.poster_path}
-            title={movie.original_title}
-            id={movie.id}
-          />
-        ))}
+        {movieList.map(
+          (movie) =>
+            movie.poster_path !== null && (
+              <CardMovie
+                key={movie.id}
+                variant="default"
+                poster={movie.poster_path}
+                title={movie.original_title}
+                id={movie.id}
+              />
+            )
+        )}
       </main>
       <Button
         variant="primary"

--- a/app/films/page.tsx
+++ b/app/films/page.tsx
@@ -144,15 +144,18 @@ const ContainerRandomMovieOne: React.FC<PropsMovieRandom> = ({
       />
       <ContainerScroll>
         {Movies &&
-          Movies.map((movie) => (
-            <CardMovie
-              key={movie.id}
-              variant="primary"
-              poster={movie.poster_path}
-              title={movie.title}
-              id={movie.id}
-            />
-          ))}
+          Movies.map(
+            (movie) =>
+              movie.poster_path !== null && (
+                <CardMovie
+                  key={movie.id}
+                  variant="primary"
+                  poster={movie.poster_path}
+                  title={movie.title}
+                  id={movie.id}
+                />
+              )
+          )}
       </ContainerScroll>
     </section>
   );
@@ -214,15 +217,18 @@ const ContainerRandomMovieTwo: React.FC<PropsMovieRandom> = ({
       />
       <ContainerScroll>
         {Movies &&
-          Movies.map((movie) => (
-            <CardMovie
-              key={movie.id}
-              variant="primary"
-              poster={movie.poster_path}
-              title={movie.title}
-              id={movie.id}
-            />
-          ))}
+          Movies.map(
+            (movie) =>
+              movie.poster_path !== null && (
+                <CardMovie
+                  key={movie.id}
+                  variant="primary"
+                  poster={movie.poster_path}
+                  title={movie.title}
+                  id={movie.id}
+                />
+              )
+          )}
       </ContainerScroll>
     </section>
   );
@@ -284,15 +290,18 @@ const ContainerRandomMovieThree: React.FC<PropsMovieRandom> = ({
       />
       <ContainerScroll>
         {Movies &&
-          Movies.map((movie) => (
-            <CardMovie
-              key={movie.id}
-              variant="primary"
-              poster={movie.poster_path}
-              title={movie.title}
-              id={movie.id}
-            />
-          ))}
+          Movies.map(
+            (movie) =>
+              movie.poster_path !== null && (
+                <CardMovie
+                  key={movie.id}
+                  variant="primary"
+                  poster={movie.poster_path}
+                  title={movie.title}
+                  id={movie.id}
+                />
+              )
+          )}
       </ContainerScroll>
     </section>
   );
@@ -354,15 +363,18 @@ const ContainerRandomMovieFour: React.FC<PropsMovieRandom> = ({
       />
       <ContainerScroll>
         {Movies &&
-          Movies.map((movie) => (
-            <CardMovie
-              key={movie.id}
-              variant="primary"
-              poster={movie.poster_path}
-              title={movie.title}
-              id={movie.id}
-            />
-          ))}
+          Movies.map(
+            (movie) =>
+              movie.poster_path !== null && (
+                <CardMovie
+                  key={movie.id}
+                  variant="primary"
+                  poster={movie.poster_path}
+                  title={movie.title}
+                  id={movie.id}
+                />
+              )
+          )}
       </ContainerScroll>
     </section>
   );
@@ -424,15 +436,18 @@ const ContainerRandomMovieFive: React.FC<PropsMovieRandom> = ({
       />
       <ContainerScroll>
         {Movies &&
-          Movies.map((movie) => (
-            <CardMovie
-              key={movie.id}
-              variant="primary"
-              poster={movie.poster_path}
-              title={movie.title}
-              id={movie.id}
-            />
-          ))}
+          Movies.map(
+            (movie) =>
+              movie.poster_path !== null && (
+                <CardMovie
+                  key={movie.id}
+                  variant="primary"
+                  poster={movie.poster_path}
+                  title={movie.title}
+                  id={movie.id}
+                />
+              )
+          )}
       </ContainerScroll>
     </section>
   );

--- a/app/films/popular/page.tsx
+++ b/app/films/popular/page.tsx
@@ -81,15 +81,18 @@ const ContainerMovie = () => {
       id="content__movie_tv"
     >
       <main className="content">
-        {movieList.map((movie, index) => (
-          <CardMovie
-            key={index}
-            variant="default"
-            poster={movie.poster_path}
-            title={movie.original_title}
-            id={movie.id}
-          />
-        ))}
+        {movieList.map(
+          (movie) =>
+            movie.poster_path !== null && (
+              <CardMovie
+                key={movie.id}
+                variant="default"
+                poster={movie.poster_path}
+                title={movie.original_title}
+                id={movie.id}
+              />
+            )
+        )}
       </main>
       <Button
         variant="primary"

--- a/app/films/trending/page.tsx
+++ b/app/films/trending/page.tsx
@@ -86,15 +86,18 @@ const ContainerMovie = () => {
       id="content__movie_tv"
     >
       <main className="content">
-        {movieList.map((movie, index) => (
-          <CardMovie
-            key={index}
-            variant="default"
-            poster={movie.poster_path}
-            title={movie.original_title}
-            id={movie.id}
-          />
-        ))}
+        {movieList.map(
+          (movie) =>
+            movie.poster_path !== null && (
+              <CardMovie
+                key={movie.id}
+                variant="default"
+                poster={movie.poster_path}
+                title={movie.original_title}
+                id={movie.id}
+              />
+            )
+        )}
       </main>
       <Button
         variant="primary"

--- a/app/films/tv/[id]/page.tsx
+++ b/app/films/tv/[id]/page.tsx
@@ -6,7 +6,12 @@ import { ContainerScroll } from "@/components/container/container";
 import "./style.scss";
 import LoaderPage from "@/components/loader/loader";
 import { Suspense } from "react";
-import { DetailMovie, DetailTvMovie, TypeMovieDetails } from "@/types/movie";
+import {
+  DetailMovie,
+  DetailTvMovie,
+  TVShow,
+  TypeMovieDetails,
+} from "@/types/movie";
 import { CardCategorie, CardMovie } from "@/components/card/card";
 import { TitleSection } from "@/components/titleSection/titleSection";
 import { MdStarRate } from "react-icons/md";
@@ -107,7 +112,7 @@ const Banner = ({ movie, isLoading }: propsBanner) => {
   return displayContainer;
 };
 
-type SimilarMovies = TypeMovieDetails[];
+type SimilarMovies = TVShow[];
 type propsSimilarMovie = {
   movie?: SimilarMovies;
   isLoading: boolean;
@@ -117,6 +122,7 @@ const ContainerMovieSimilar = ({ movie, isLoading }: propsSimilarMovie) => {
   const loadingCardMovies = Array.from({ length: 10 }).map((_, index) => (
     <CardMovie variant="primary" key={index} isLoading={true} />
   ));
+  console.log(movie);
   return (
     <section className="section__page sections__movies">
       <TitleSection variant="title-large" title="SERIE SIMILAIRES" />
@@ -125,13 +131,14 @@ const ContainerMovieSimilar = ({ movie, isLoading }: propsSimilarMovie) => {
           ? loadingCardMovies
           : movie &&
             movie
+              .filter((movie: TVShow) => movie.poster_path !== null)
               .slice(0, 20)
-              .map((movie: TypeMovieDetails) => (
+              .map((movie: TVShow) => (
                 <CardMovie
                   key={movie.id}
                   variant="primary"
                   poster={movie.poster_path}
-                  title={movie.title}
+                  title={movie.original_name}
                   id={movie.id}
                   forTv={true}
                 />

--- a/app/films/upcoming/page.tsx
+++ b/app/films/upcoming/page.tsx
@@ -83,15 +83,18 @@ const ContainerMovie = () => {
       id="content__movie_tv"
     >
       <main className="content">
-        {movieList.map((movie, index) => (
-          <CardMovie
-            key={index}
-            variant="default"
-            poster={movie.poster_path}
-            title={movie.original_title}
-            id={movie.id}
-          />
-        ))}
+        {movieList.map(
+          (movie) =>
+            movie.poster_path !== null && (
+              <CardMovie
+                key={movie.id}
+                variant="default"
+                poster={movie.poster_path}
+                title={movie.original_title}
+                id={movie.id}
+              />
+            )
+        )}
       </main>
       <Button
         variant="primary"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,7 +15,6 @@ import { TypeMovieOverview, TypeMovieDetails, TVShow } from "@/types/movie";
 import { fakeDataPopularMovie } from "@/data/fakeData.PopularMovie";
 import { useEffect, useState, useMemo } from "react";
 import { TypeMovieCategory } from "@/types/categorie";
-import { dataGenreMovie } from "@/data/genreMovie";
 import LoaderPage from "@/components/loader/loader";
 import { Suspense } from "react";
 import {
@@ -106,15 +105,20 @@ const BannerHomePage = () => {
       <div className="container__similar_movie">
         <TitleSection variant="title-small" title="FILM SIMILAIRE" />
         <ContainerScroll>
-          {similarMovie.slice(0, 10).map((movie) => (
-            <CardMovie
-              key={movie.id}
-              variant="primary"
-              poster={movie.poster_path}
-              title={movie.title}
-              id={movie.id}
-            />
-          ))}
+          {similarMovie
+            .slice(0, 10)
+            .map(
+              (movie) =>
+                movie.poster_path !== null && (
+                  <CardMovie
+                    key={movie.id}
+                    variant="primary"
+                    poster={movie.poster_path}
+                    title={movie.title}
+                    id={movie.id}
+                  />
+                )
+            )}
         </ContainerScroll>
       </div>
     </section>
@@ -206,15 +210,18 @@ const PopularMoviesSection = () => {
         <ContainerScroll>
           {isLoading
             ? loadingCardMovies
-            : moviesPopular.map((movie: TypeMovieDetails, index: number) => (
-                <CardMovie
-                  key={movie.id}
-                  variant="popular"
-                  poster={movie.poster_path}
-                  onClick={() => handleCardClick(index)}
-                  isSelected={index === selectedMovieIndex}
-                />
-              ))}
+            : moviesPopular.map(
+                (movie: TypeMovieDetails, index: number) =>
+                  movie.poster_path !== null && (
+                    <CardMovie
+                      key={movie.id}
+                      variant="popular"
+                      poster={movie.poster_path}
+                      onClick={() => handleCardClick(index)}
+                      isSelected={index === selectedMovieIndex}
+                    />
+                  )
+              )}
         </ContainerScroll>
       </section>
       <ContainerCurrentPopularMovie
@@ -247,15 +254,18 @@ const ContainerFilmsRecent = () => {
           ? loadingCardMovies
           : recentMovie
               .slice(0, 20)
-              .map((movie: TypeMovieDetails) => (
-                <CardMovie
-                  key={movie.id}
-                  variant="primary"
-                  poster={movie.poster_path}
-                  title={movie.title}
-                  id={movie.id}
-                />
-              ))}
+              .map(
+                (movie: TypeMovieDetails) =>
+                  movie.poster_path !== null && (
+                    <CardMovie
+                      key={movie.id}
+                      variant="primary"
+                      poster={movie.poster_path}
+                      title={movie.title}
+                      id={movie.id}
+                    />
+                  )
+              )}
       </ContainerScroll>
     </section>
   );
@@ -371,15 +381,18 @@ const PlayingMoviesSection = () => {
         <ContainerScroll>
           {isLoading
             ? loadingCardMovies
-            : moviesTrending.map((movie: TypeMovieDetails, index: number) => (
-                <CardMovie
-                  key={movie.id}
-                  variant="simple"
-                  poster={movie.poster_path}
-                  onClick={() => handleCardClick(index)}
-                  isSelected={index === selectedMovieIndex}
-                />
-              ))}
+            : moviesTrending.map(
+                (movie: TypeMovieDetails, index: number) =>
+                  movie.poster_path !== null && (
+                    <CardMovie
+                      key={movie.id}
+                      variant="simple"
+                      poster={movie.poster_path}
+                      onClick={() => handleCardClick(index)}
+                      isSelected={index === selectedMovieIndex}
+                    />
+                  )
+              )}
         </ContainerScroll>
       </section>
     </>
@@ -441,15 +454,18 @@ const ContainerRandomMovieOne: React.FC<PropsMovieRandom> = ({
       />
       <ContainerScroll>
         {Movies &&
-          Movies.map((movie) => (
-            <CardMovie
-              key={movie.id}
-              variant="primary"
-              poster={movie.poster_path}
-              title={movie.title}
-              id={movie.id}
-            />
-          ))}
+          Movies.map(
+            (movie) =>
+              movie.poster_path !== null && (
+                <CardMovie
+                  key={movie.id}
+                  variant="primary"
+                  poster={movie.poster_path}
+                  title={movie.title}
+                  id={movie.id}
+                />
+              )
+          )}
       </ContainerScroll>
     </section>
   );
@@ -511,15 +527,18 @@ const ContainerRandomMovieTwo: React.FC<PropsMovieRandom> = ({
       />
       <ContainerScroll>
         {Movies &&
-          Movies.map((movie) => (
-            <CardMovie
-              key={movie.id}
-              variant="primary"
-              poster={movie.poster_path}
-              title={movie.title}
-              id={movie.id}
-            />
-          ))}
+          Movies.map(
+            (movie) =>
+              movie.poster_path !== null && (
+                <CardMovie
+                  key={movie.id}
+                  variant="primary"
+                  poster={movie.poster_path}
+                  title={movie.title}
+                  id={movie.id}
+                />
+              )
+          )}
       </ContainerScroll>
     </section>
   );
@@ -656,15 +675,18 @@ const UpcomingMoviesSection = () => {
         <ContainerScroll>
           {isLoading
             ? loadingCardMovies
-            : moviesUpcoming.map((movie: TypeMovieDetails, index: number) => (
-                <CardMovie
-                  key={movie.id}
-                  variant="simple"
-                  poster={movie.poster_path}
-                  onClick={() => handleCardClick(index)}
-                  isSelected={index === selectedMovieIndex}
-                />
-              ))}
+            : moviesUpcoming.map(
+                (movie: TypeMovieDetails, index: number) =>
+                  movie.poster_path !== null && (
+                    <CardMovie
+                      key={movie.id}
+                      variant="simple"
+                      poster={movie.poster_path}
+                      onClick={() => handleCardClick(index)}
+                      isSelected={index === selectedMovieIndex}
+                    />
+                  )
+              )}
         </ContainerScroll>
       </section>
     </>
@@ -698,16 +720,19 @@ const ContainerTvMoivies = () => {
           ? loadingCardMovies
           : trendigMovieTv
               .slice(0, 20)
-              .map((tvShow: TVShow) => (
-                <CardMovie
-                  key={tvShow.id}
-                  variant="primary"
-                  poster={tvShow.poster_path}
-                  title={tvShow.name}
-                  id={tvShow.id}
-                  forTv={true}
-                />
-              ))}
+              .map(
+                (tvShow: TVShow) =>
+                  tvShow.poster_path !== null && (
+                    <CardMovie
+                      key={tvShow.id}
+                      variant="primary"
+                      poster={tvShow.poster_path}
+                      title={tvShow.name}
+                      id={tvShow.id}
+                      forTv={true}
+                    />
+                  )
+              )}
       </ContainerScroll>
     </section>
   );

--- a/app/tv/page.tsx
+++ b/app/tv/page.tsx
@@ -87,16 +87,19 @@ const ContainerMovieTV = () => {
       id="content__movie_tv"
     >
       <main className="content">
-        {movieTrendingTv.map((movie, index) => (
-          <CardMovie
-            key={index}
-            variant="default"
-            poster={movie.poster_path}
-            title={movie.original_name}
-            id={movie.id}
-            forTv={true}
-          />
-        ))}
+        {movieTrendingTv.map(
+          (movie, index) =>
+            movie.poster_path !== null && (
+              <CardMovie
+                key={index}
+                variant="default"
+                poster={movie.poster_path}
+                title={movie.original_name}
+                id={movie.id}
+                forTv={true}
+              />
+            )
+        )}
       </main>
       <Button
         variant="primary"

--- a/components/card/card.tsx
+++ b/components/card/card.tsx
@@ -36,6 +36,7 @@ interface CardProps {
   isLoading?: boolean;
   isSelected?: boolean;
   forTv?: boolean;
+  cover?: string;
   onClick?: () => void;
 }
 
@@ -166,11 +167,13 @@ export const CardMovieFavorite: React.FC<CardFavoriteMovieProps> = ({
     </div>
   );
 };
+
 export const CardMovie: React.FC<CardProps> = ({
   variant,
   id,
   title,
   poster,
+  cover,
   isLoading,
   isSelected,
   forTv,
@@ -188,7 +191,9 @@ export const CardMovie: React.FC<CardProps> = ({
             <>
               {poster && (
                 <Image
-                  src={`https://image.tmdb.org/t/p/original${poster}`}
+                  src={`https://image.tmdb.org/t/p/original${
+                    poster === null ? cover : poster
+                  }`}
                   alt={`poster movie ${title}`}
                   className="img-fluid poster-movie"
                   width={100}
@@ -256,7 +261,7 @@ export const CardMovie: React.FC<CardProps> = ({
           {isLoading ? (
             <div className="skeleton-loading"></div>
           ) : (
-            poster && (
+            poster !== null && (
               <Image
                 src={`https://image.tmdb.org/t/p/original${poster}`}
                 alt={`poster movie ${title}`}
@@ -280,7 +285,7 @@ export const CardMovie: React.FC<CardProps> = ({
           {isLoading ? (
             <div className="skeleton-loading"></div>
           ) : (
-            poster && (
+            poster !== null && (
               <Image
                 src={`https://image.tmdb.org/t/p/original${poster}`}
                 alt={`poster movie ${title}`}


### PR DESCRIPTION
In components where CardMovies are rendered from data, items without a poster_path are now filtered out before rendering. This ensures that only items with a valid poster_path are displayed in movie and TV show lists.

This improves the user experience by showing only content with associated images, helping users easily find the movies and shows they want to view.